### PR TITLE
Include README, LICENSE, and bin in gem

### DIFF
--- a/editorconfig.gemspec
+++ b/editorconfig.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |s|
   s.files = [
     "lib/editor_config.rb",
     "lib/editor_config/version.rb",
-    "lib/editorconfig.rb"
+    "lib/editorconfig.rb",
+    "bin/editorconfig",
+    "README.md",
+    "LICENSE.md"
   ]
+
+  s.executables << "editorconfig"
 end


### PR DESCRIPTION
Currently only `lib/*` is in the gem. This adds  `README.md`, `LICENSE.md`, and `bin/editorconfig`.