### PR TITLE
fix editorconfig url on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ EditorConfig Ruby Core provides the same functionality as the [EditorConfig C Co
 
 ## EditorConfig Project
 
-EditorConfig makes it easy to maintain the correct coding style when switching between different text editors and between different projects. The EditorConfig project maintains a file format and plugins for various text editors which allow this file format to be read and used by those editors. For information on the file format and supported text editors, see the [EditorConfig website](http://editorconfig.org>).
+EditorConfig makes it easy to maintain the correct coding style when switching between different text editors and between different projects. The EditorConfig project maintains a file format and plugins for various text editors which allow this file format to be read and used by those editors. For information on the file format and supported text editors, see the [EditorConfig website](http://editorconfig.org).
 
 ## Installation
 


### PR DESCRIPTION
This PR fix a little bug on README.md when try to link editorconfig website